### PR TITLE
chore: modernize Terraform and provider versions

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -2,11 +2,11 @@
 # Licensed under the MIT License.
 
 terraform {
-  required_version = ">= 1.3"
+  required_version = ">= 1.9"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.36"
+      version = "~> 3.116"
     }
     azapi = {
       source  = "Azure/azapi"


### PR DESCRIPTION
## Summary
Modernize version constraints to current standards.
### Changes
- Terraform `>= 1.9`
- azurerm `~> 3.116`
- Updated examples and documentation
Closes #4