### PR TITLE
fix: correct truncated module source slugs (tf-az-overlays → terraform-az-overlays)

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,10 +1,10 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: tf-az-overlays-sentinel
+  name: terraform-az-overlays-sentinel
   description: Terraform overlay module for Microsoft Sentinel
   annotations:
-    github.com/project-slug: POps-Rox/tf-az-overlays-sentinel
+    github.com/project-slug: POps-Rox/terraform-az-overlays-sentinel
     backstage.io/techdocs-ref: dir:.
   tags:
     - terraform
@@ -12,7 +12,7 @@ metadata:
     - azure
     - platform-ops
   links:
-    - url: https://github.com/POps-Rox/tf-az-overlays-sentinel
+    - url: https://github.com/POps-Rox/terraform-az-overlays-sentinel
       title: GitHub Repository
       icon: github
 spec:

--- a/examples/Commerical/add_aad_monitor_settings/dependencies.tf
+++ b/examples/Commerical/add_aad_monitor_settings/dependencies.tf
@@ -5,7 +5,7 @@
 # Azure Region Lookup
 #----------------------------------------------------------
 module "mod_azure_region_lookup" {
-  source = "github.com/POps-Rox/tf-az-overlays-azregionslookup"
+  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup"
 
   azure_region = "eastus"
 }

--- a/examples/Commerical/add_aad_monitor_settings/main.tf
+++ b/examples/Commerical/add_aad_monitor_settings/main.tf
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 module "mod_sentinel_aad_monitor_settings" {
-  #source = "github.com/POps-Rox/tf-az-overlays-sentinel"  
+  #source = "github.com/POps-Rox/terraform-az-overlays-sentinel"  
   #version = "x.x.x"  
   source     = "../../.."
   depends_on = [azurerm_log_analytics_workspace.sentinel_workspace, azurerm_storage_account.sentinel_storage_account, azurerm_log_analytics_solution.solutions]

--- a/examples/Commerical/add_automation_rule/dependencies.tf
+++ b/examples/Commerical/add_automation_rule/dependencies.tf
@@ -5,7 +5,7 @@
 # Azure Region Lookup
 #----------------------------------------------------------
 module "mod_azure_region_lookup" {
-  source = "github.com/POps-Rox/tf-az-overlays-azregionslookup"
+  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup"
 
   azure_region = "eastus"
 }

--- a/examples/Commerical/add_automation_rule/main.tf
+++ b/examples/Commerical/add_automation_rule/main.tf
@@ -3,7 +3,7 @@
 
 # Enable SOAR Essentials for Send Email and Create Incident
 module "mod_sentinel_content_hub_solutions" {
-  #source = "github.com/POps-Rox/tf-az-overlays-sentinel"  
+  #source = "github.com/POps-Rox/terraform-az-overlays-sentinel"  
   #version = "x.x.x"  
   source     = "../../.."
   depends_on = [azurerm_log_analytics_workspace.sentinel_workspace, azurerm_log_analytics_solution.solutions]
@@ -22,7 +22,7 @@ module "mod_sentinel_content_hub_solutions" {
 }
 
 module "mod_sentinel_automation_rule" {
-  #source = "github.com/POps-Rox/tf-az-overlays-sentinel"  
+  #source = "github.com/POps-Rox/terraform-az-overlays-sentinel"  
   #version = "x.x.x"  
   source     = "../../.."
   depends_on = [azurerm_log_analytics_workspace.sentinel_workspace, azurerm_storage_account.sentinel_storage_account, azurerm_log_analytics_solution.solutions]

--- a/examples/Commerical/add_content_hub_solutions/dependencies.tf
+++ b/examples/Commerical/add_content_hub_solutions/dependencies.tf
@@ -5,7 +5,7 @@
 # Azure Region Lookup
 #----------------------------------------------------------
 module "mod_azure_region_lookup" {
-  source = "github.com/POps-Rox/tf-az-overlays-azregionslookup"
+  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup"
 
   azure_region = "eastus"
 }

--- a/examples/Commerical/add_content_hub_solutions/main.tf
+++ b/examples/Commerical/add_content_hub_solutions/main.tf
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 module "mod_sentinel_content_hub_solutions" {
-  #source = "github.com/POps-Rox/tf-az-overlays-sentinel"  
+  #source = "github.com/POps-Rox/terraform-az-overlays-sentinel"  
   #version = "x.x.x"  
   source     = "../../.."
   depends_on = [azurerm_log_analytics_workspace.sentinel_workspace, azurerm_log_analytics_solution.solutions]

--- a/examples/Commerical/add_data_connector/dependencies.tf
+++ b/examples/Commerical/add_data_connector/dependencies.tf
@@ -2,7 +2,7 @@
 # Azure Region Lookup
 #----------------------------------------------------------
 module "mod_azure_region_lookup" {
-  source = "github.com/POps-Rox/tf-az-overlays-azregionslookup"
+  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup"
 
   azure_region = "eastus"
 }

--- a/examples/Commerical/add_data_connector/main.tf
+++ b/examples/Commerical/add_data_connector/main.tf
@@ -1,7 +1,7 @@
 
 
 module "mod_sentinel_connector" {
-  #source = "github.com/POps-Rox/tf-az-overlays-sentinel"  
+  #source = "github.com/POps-Rox/terraform-az-overlays-sentinel"  
   #version = "x.x.x"  
   source     = "../../.."
   depends_on = [azurerm_log_analytics_workspace.sentinel_workspace, azurerm_log_analytics_solution.solutions]

--- a/examples/Commerical/add_fusion_rule_alert/dependencies.tf
+++ b/examples/Commerical/add_fusion_rule_alert/dependencies.tf
@@ -5,7 +5,7 @@
 # Azure Region Lookup
 #----------------------------------------------------------
 module "mod_azure_region_lookup" {
-  source = "github.com/POps-Rox/tf-az-overlays-azregionslookup"
+  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup"
 
   azure_region = "eastus"
 }

--- a/examples/Commerical/add_fusion_rule_alert/main.tf
+++ b/examples/Commerical/add_fusion_rule_alert/main.tf
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 module "mod_sentinel_fusion_alert_rule" {
-  #source = "github.com/POps-Rox/tf-az-overlays-sentinel"  
+  #source = "github.com/POps-Rox/terraform-az-overlays-sentinel"  
   #version = "x.x.x"  
   source     = "../../.."
   depends_on = [azurerm_log_analytics_workspace.sentinel_workspace, azurerm_storage_account.sentinel_storage_account, azurerm_log_analytics_solution.solutions]

--- a/examples/Commerical/add_machine_learning_behavior_analytics_alert_rule/dependencies.tf
+++ b/examples/Commerical/add_machine_learning_behavior_analytics_alert_rule/dependencies.tf
@@ -5,7 +5,7 @@
 # Azure Region Lookup
 #----------------------------------------------------------
 module "mod_azure_region_lookup" {
-  source = "github.com/POps-Rox/tf-az-overlays-azregionslookup"
+  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup"
 
   azure_region = "eastus"
 }

--- a/examples/Commerical/add_machine_learning_behavior_analytics_alert_rule/main.tf
+++ b/examples/Commerical/add_machine_learning_behavior_analytics_alert_rule/main.tf
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 module "mod_sentinel_machine_learning_behavior_analytics_alert_rule" {
-  #source = "github.com/POps-Rox/tf-az-overlays-sentinel"  
+  #source = "github.com/POps-Rox/terraform-az-overlays-sentinel"  
   #version = "x.x.x"  
   source     = "../../.."
   depends_on = [azurerm_log_analytics_workspace.sentinel_workspace, azurerm_storage_account.sentinel_storage_account, azurerm_log_analytics_solution.solutions]

--- a/examples/Commerical/add_ms_incident_rule_alert/dependencies.tf
+++ b/examples/Commerical/add_ms_incident_rule_alert/dependencies.tf
@@ -5,7 +5,7 @@
 # Azure Region Lookup
 #----------------------------------------------------------
 module "mod_azure_region_lookup" {
-  source = "github.com/POps-Rox/tf-az-overlays-azregionslookup"
+  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup"
 
   azure_region = "eastus"
 }

--- a/examples/Commerical/add_ms_incident_rule_alert/main.tf
+++ b/examples/Commerical/add_ms_incident_rule_alert/main.tf
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 module "mod_sentinel_ms_security_incident_alert_rule" {
-  #source = "github.com/POps-Rox/tf-az-overlays-sentinel"  
+  #source = "github.com/POps-Rox/terraform-az-overlays-sentinel"  
   #version = "x.x.x"  
   source     = "../../.."
   depends_on = [azurerm_log_analytics_workspace.sentinel_workspace, azurerm_storage_account.sentinel_storage_account, azurerm_log_analytics_solution.solutions]

--- a/examples/Commerical/add_scheduled_alert_rule/dependencies.tf
+++ b/examples/Commerical/add_scheduled_alert_rule/dependencies.tf
@@ -5,7 +5,7 @@
 # Azure Region Lookup
 #----------------------------------------------------------
 module "mod_azure_region_lookup" {
-  source = "github.com/POps-Rox/tf-az-overlays-azregionslookup"
+  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup"
 
   azure_region = "eastus"
 }

--- a/examples/Commerical/add_scheduled_alert_rule/main.tf
+++ b/examples/Commerical/add_scheduled_alert_rule/main.tf
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 module "mod_sentinel_scheduled_alert_rule" {
-  #source = "github.com/POps-Rox/tf-az-overlays-sentinel"  
+  #source = "github.com/POps-Rox/terraform-az-overlays-sentinel"  
   #version = "x.x.x"  
   source     = "../../.."
   depends_on = [azurerm_log_analytics_workspace.sentinel_workspace, azurerm_storage_account.sentinel_storage_account, azurerm_log_analytics_solution.solutions]

--- a/examples/Commerical/ueba/dependencies.tf
+++ b/examples/Commerical/ueba/dependencies.tf
@@ -2,7 +2,7 @@
 # Azure Region Lookup
 #----------------------------------------------------------
 module "mod_azure_region_lookup" {
-  source = "github.com/POps-Rox/tf-az-overlays-azregionslookup"
+  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup"
 
   azure_region = "eastus"
 }

--- a/examples/Commerical/ueba/main.tf
+++ b/examples/Commerical/ueba/main.tf
@@ -1,7 +1,7 @@
 
 
 module "mod_sentinel_ubea" {
-  #source = "github.com/POps-Rox/tf-az-overlays-sentinel"  
+  #source = "github.com/POps-Rox/terraform-az-overlays-sentinel"  
   #version = "x.x.x"  
   source     = "../../.."
   depends_on = [azurerm_log_analytics_workspace.sentinel_workspace, azurerm_storage_account.sentinel_storage_account, azurerm_log_analytics_solution.solutions]

--- a/examples/Government/add_aad_monitor_settings/dependencies.tf
+++ b/examples/Government/add_aad_monitor_settings/dependencies.tf
@@ -5,7 +5,7 @@
 # Azure Region Lookup
 #----------------------------------------------------------
 module "mod_azure_region_lookup" {
-  source = "github.com/POps-Rox/tf-az-overlays-azregionslookup"
+  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup"
 
   azure_region = "usgovvirginia"
 }

--- a/examples/Government/add_aad_monitor_settings/main.tf
+++ b/examples/Government/add_aad_monitor_settings/main.tf
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 module "mod_sentinel_aad_monitor_settings" {
-  #source = "github.com/POps-Rox/tf-az-overlays-sentinel"
+  #source = "github.com/POps-Rox/terraform-az-overlays-sentinel"
   #version = "x.x.x"
   source     = "../../.."
   depends_on = [azurerm_log_analytics_workspace.sentinel_workspace, azurerm_storage_account.sentinel_storage_account, azurerm_log_analytics_solution.solutions]

--- a/examples/Government/add_automation_rule/dependencies.tf
+++ b/examples/Government/add_automation_rule/dependencies.tf
@@ -5,7 +5,7 @@
 # Azure Region Lookup
 #----------------------------------------------------------
 module "mod_azure_region_lookup" {
-  source = "github.com/POps-Rox/tf-az-overlays-azregionslookup"
+  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup"
 
   azure_region = "usgovvirginia"
 }

--- a/examples/Government/add_automation_rule/main.tf
+++ b/examples/Government/add_automation_rule/main.tf
@@ -3,7 +3,7 @@
 
 # Enable SOAR Essentials for Send Email and Create Incident
 module "mod_sentinel_content_hub_solutions" {
-  #source = "github.com/POps-Rox/tf-az-overlays-sentinel"
+  #source = "github.com/POps-Rox/terraform-az-overlays-sentinel"
   #version = "x.x.x"
   source     = "../../.."
   depends_on = [azurerm_log_analytics_workspace.sentinel_workspace, azurerm_log_analytics_solution.solutions]
@@ -23,7 +23,7 @@ module "mod_sentinel_content_hub_solutions" {
 
 
 module "mod_sentinel_automation_rule" {
-  #source = "github.com/POps-Rox/tf-az-overlays-sentinel"
+  #source = "github.com/POps-Rox/terraform-az-overlays-sentinel"
   #version = "x.x.x"
   source     = "../../.."
   depends_on = [azurerm_log_analytics_workspace.sentinel_workspace, azurerm_storage_account.sentinel_storage_account, azurerm_log_analytics_solution.solutions]

--- a/examples/Government/add_content_hub_solutions/dependencies.tf
+++ b/examples/Government/add_content_hub_solutions/dependencies.tf
@@ -5,7 +5,7 @@
 # Azure Region Lookup
 #----------------------------------------------------------
 module "mod_azure_region_lookup" {
-  source = "github.com/POps-Rox/tf-az-overlays-azregionslookup"
+  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup"
 
   azure_region = "usgovvirginia"
 }

--- a/examples/Government/add_content_hub_solutions/main.tf
+++ b/examples/Government/add_content_hub_solutions/main.tf
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 module "mod_sentinel_content_hub_solutions" {
-  #source = "github.com/POps-Rox/tf-az-overlays-sentinel"
+  #source = "github.com/POps-Rox/terraform-az-overlays-sentinel"
   #version = "x.x.x"
   source     = "../../.."
   depends_on = [azurerm_log_analytics_workspace.sentinel_workspace, azurerm_log_analytics_solution.solutions]

--- a/examples/Government/add_data_connector/dependencies.tf
+++ b/examples/Government/add_data_connector/dependencies.tf
@@ -2,7 +2,7 @@
 # Azure Region Lookup
 #----------------------------------------------------------
 module "mod_azure_region_lookup" {
-  source = "github.com/POps-Rox/tf-az-overlays-azregionslookup"
+  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup"
 
   azure_region = "usgovvirginia"
 }

--- a/examples/Government/add_data_connector/main.tf
+++ b/examples/Government/add_data_connector/main.tf
@@ -1,7 +1,7 @@
 
 
 module "mod_sentinel_connector" {
-  #source = "github.com/POps-Rox/tf-az-overlays-sentinel"
+  #source = "github.com/POps-Rox/terraform-az-overlays-sentinel"
   #version = "x.x.x"
   source     = "../../.."
   depends_on = [azurerm_log_analytics_workspace.sentinel_workspace, azurerm_log_analytics_solution.solutions]

--- a/examples/Government/add_fusion_rule_alert/dependencies.tf
+++ b/examples/Government/add_fusion_rule_alert/dependencies.tf
@@ -5,7 +5,7 @@
 # Azure Region Lookup
 #----------------------------------------------------------
 module "mod_azure_region_lookup" {
-  source = "github.com/POps-Rox/tf-az-overlays-azregionslookup"
+  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup"
 
   azure_region = "usgovvirginia"
 }

--- a/examples/Government/add_fusion_rule_alert/main.tf
+++ b/examples/Government/add_fusion_rule_alert/main.tf
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 module "mod_sentinel_fusion_alert_rule" {
-  #source = "github.com/POps-Rox/tf-az-overlays-sentinel"
+  #source = "github.com/POps-Rox/terraform-az-overlays-sentinel"
   #version = "x.x.x"
   source     = "../../.."
   depends_on = [azurerm_log_analytics_workspace.sentinel_workspace, azurerm_storage_account.sentinel_storage_account, azurerm_log_analytics_solution.solutions]

--- a/examples/Government/add_machine_learning_behavior_analytics_alert_rule/dependencies.tf
+++ b/examples/Government/add_machine_learning_behavior_analytics_alert_rule/dependencies.tf
@@ -5,7 +5,7 @@
 # Azure Region Lookup
 #----------------------------------------------------------
 module "mod_azure_region_lookup" {
-  source = "github.com/POps-Rox/tf-az-overlays-azregionslookup"
+  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup"
 
   azure_region = "usgovvirginia"
 }

--- a/examples/Government/add_machine_learning_behavior_analytics_alert_rule/main.tf
+++ b/examples/Government/add_machine_learning_behavior_analytics_alert_rule/main.tf
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 module "mod_sentinel_machine_learning_behavior_analytics_alert_rule" {
-  #source = "github.com/POps-Rox/tf-az-overlays-sentinel"
+  #source = "github.com/POps-Rox/terraform-az-overlays-sentinel"
   #version = "x.x.x"
   source     = "../../.."
   depends_on = [azurerm_log_analytics_workspace.sentinel_workspace, azurerm_storage_account.sentinel_storage_account, azurerm_log_analytics_solution.solutions]

--- a/examples/Government/add_ms_incident_rule_alert/dependencies.tf
+++ b/examples/Government/add_ms_incident_rule_alert/dependencies.tf
@@ -5,7 +5,7 @@
 # Azure Region Lookup
 #----------------------------------------------------------
 module "mod_azure_region_lookup" {
-  source = "github.com/POps-Rox/tf-az-overlays-azregionslookup"
+  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup"
 
   azure_region = "usgovvirginia"
 }

--- a/examples/Government/add_ms_incident_rule_alert/main.tf
+++ b/examples/Government/add_ms_incident_rule_alert/main.tf
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 module "mod_sentinel_ms_security_incident_alert_rule" {
-  #source = "github.com/POps-Rox/tf-az-overlays-sentinel"
+  #source = "github.com/POps-Rox/terraform-az-overlays-sentinel"
   #version = "x.x.x"
   source     = "../../.."
   depends_on = [azurerm_log_analytics_workspace.sentinel_workspace, azurerm_storage_account.sentinel_storage_account, azurerm_log_analytics_solution.solutions]

--- a/examples/Government/add_scheduled_alert_rule/dependencies.tf
+++ b/examples/Government/add_scheduled_alert_rule/dependencies.tf
@@ -5,7 +5,7 @@
 # Azure Region Lookup
 #----------------------------------------------------------
 module "mod_azure_region_lookup" {
-  source = "github.com/POps-Rox/tf-az-overlays-azregionslookup"
+  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup"
 
   azure_region = "usgovvirginia"
 }

--- a/examples/Government/add_scheduled_alert_rule/main.tf
+++ b/examples/Government/add_scheduled_alert_rule/main.tf
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 module "mod_sentinel_scheduled_alert_rule" {
-  #source = "github.com/POps-Rox/tf-az-overlays-sentinel"
+  #source = "github.com/POps-Rox/terraform-az-overlays-sentinel"
   #version = "x.x.x"
   source     = "../../.."
   depends_on = [azurerm_log_analytics_workspace.sentinel_workspace, azurerm_storage_account.sentinel_storage_account, azurerm_log_analytics_solution.solutions]

--- a/examples/Government/ueba/dependencies.tf
+++ b/examples/Government/ueba/dependencies.tf
@@ -2,7 +2,7 @@
 # Azure Region Lookup
 #----------------------------------------------------------
 module "mod_azure_region_lookup" {
-  source = "github.com/POps-Rox/tf-az-overlays-azregionslookup"
+  source = "github.com/POps-Rox/terraform-az-overlays-azregionslookup"
 
   azure_region = "usgovvirginia"
 }

--- a/examples/Government/ueba/main.tf
+++ b/examples/Government/ueba/main.tf
@@ -1,7 +1,7 @@
 
 
 module "mod_sentinel_ubea" {
-  #source = "github.com/POps-Rox/tf-az-overlays-sentinel"
+  #source = "github.com/POps-Rox/terraform-az-overlays-sentinel"
   #version = "x.x.x"
   source     = "../../.."
   depends_on = [azurerm_log_analytics_workspace.sentinel_workspace, azurerm_storage_account.sentinel_storage_account, azurerm_log_analytics_solution.solutions]

--- a/modules.content.solutions.essentials.tf
+++ b/modules.content.solutions.essentials.tf
@@ -4,7 +4,7 @@
 # Enable Sentinel SOAR Essentials Solution
 module "mod_soar_essentials" {
   depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.sentinel]
-  source     = "github.com/POps-Rox/tf-az-overlays-armdeployment//modules/azure_arm_deployment/resource_group"
+  source     = "github.com/POps-Rox/terraform-az-overlays-armdeployment//modules/azure_arm_deployment/resource_group"
   count      = var.enable_sentinel && var.enable_solution_soar_essentials ? 1 : 0
 
   name                = "deploy_soar_essentials_content_solution"
@@ -24,7 +24,7 @@ module "mod_soar_essentials" {
 # Enable Sentinel UEBA Essentials Solution
 module "mod_ueba_essentials" {
   depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.sentinel]
-  source     = "github.com/POps-Rox/tf-az-overlays-armdeployment//modules/azure_arm_deployment/resource_group"
+  source     = "github.com/POps-Rox/terraform-az-overlays-armdeployment//modules/azure_arm_deployment/resource_group"
   count      = var.enable_sentinel && var.enable_solution_ueba_essentials ? 1 : 0
 
   name                = "deploy_ueba_essentials_content_solution"
@@ -44,7 +44,7 @@ module "mod_ueba_essentials" {
 # Enable Sentinel Attacker Tools Threat Protection Essentials Solution
 module "mod_attacker_tools_tp_essentials" {
   depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.sentinel]
-  source     = "github.com/POps-Rox/tf-az-overlays-armdeployment//modules/azure_arm_deployment/resource_group"
+  source     = "github.com/POps-Rox/terraform-az-overlays-armdeployment//modules/azure_arm_deployment/resource_group"
   count      = var.enable_sentinel && var.enable_solution_attacker_tools_threat_protection_essentials ? 1 : 0
 
   name                = "deploy_att_tools_threat_protection_essentials_content_solution"
@@ -64,7 +64,7 @@ module "mod_attacker_tools_tp_essentials" {
 # Enable Sentinel Cloud Identity Threat Protection Essentials Solution
 module "mod_cloud_identity_tp_essentials" {
   depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.sentinel]
-  source     = "github.com/POps-Rox/tf-az-overlays-armdeployment//modules/azure_arm_deployment/resource_group"
+  source     = "github.com/POps-Rox/terraform-az-overlays-armdeployment//modules/azure_arm_deployment/resource_group"
   count      = var.enable_sentinel && var.enable_solution_cloud_identity_threat_protection_essentials ? 1 : 0
 
   name                = "deploy_cloud_id_threat_protection_essentials_content_solution"
@@ -84,7 +84,7 @@ module "mod_cloud_identity_tp_essentials" {
 # Enable Sentinel Cloud Service Threat Protection Essentials Solution
 module "mod_cloud_service_tp_essentials" {
   depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.sentinel]
-  source     = "github.com/POps-Rox/tf-az-overlays-armdeployment//modules/azure_arm_deployment/resource_group"
+  source     = "github.com/POps-Rox/terraform-az-overlays-armdeployment//modules/azure_arm_deployment/resource_group"
   count      = var.enable_sentinel && var.enable_solution_cloud_service_threat_protection_essentials ? 1 : 0
 
   name                = "deploy_cloud_svc_threat_protection_essentials_content_solution"
@@ -104,7 +104,7 @@ module "mod_cloud_service_tp_essentials" {
 # Enable Sentinel Endpoint Threat Protection Essentials Solution
 module "mod_endpoint_tp_essentials" {
   depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.sentinel]
-  source     = "github.com/POps-Rox/tf-az-overlays-armdeployment//modules/azure_arm_deployment/resource_group"
+  source     = "github.com/POps-Rox/terraform-az-overlays-armdeployment//modules/azure_arm_deployment/resource_group"
   count      = var.enable_sentinel && var.enable_solution_endpoint_threat_protection_essentials ? 1 : 0
 
   name                = "deploy_endpoint_threat_protection_essentials_content_solution"
@@ -124,7 +124,7 @@ module "mod_endpoint_tp_essentials" {
 # Enable Sentinel Network Session Essentials Solution
 module "mod_network_session_essentials" {
   depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.sentinel]
-  source     = "github.com/POps-Rox/tf-az-overlays-armdeployment//modules/azure_arm_deployment/resource_group"
+  source     = "github.com/POps-Rox/terraform-az-overlays-armdeployment//modules/azure_arm_deployment/resource_group"
   count      = var.enable_sentinel && var.enable_solution_network_session_essentials ? 1 : 0
 
   name                = "deploy_network_session_essentials_content_solution"
@@ -144,7 +144,7 @@ module "mod_network_session_essentials" {
 # Enable Sentinel Network Threat Protection Essentials Solution
 module "mod_network_tp_essentials" {
   depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.sentinel]
-  source     = "github.com/POps-Rox/tf-az-overlays-armdeployment//modules/azure_arm_deployment/resource_group"
+  source     = "github.com/POps-Rox/terraform-az-overlays-armdeployment//modules/azure_arm_deployment/resource_group"
   count      = var.enable_sentinel && var.enable_solution_network_threat_protection_essentials ? 1 : 0
 
   name                = "deploy_network_threat_protection_essentials_content_solution"
@@ -164,7 +164,7 @@ module "mod_network_tp_essentials" {
 # Enable Sentinel Security Threat Protection Essentials Solution
 module "mod_security_threat_essentials" {
   depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.sentinel]
-  source     = "github.com/POps-Rox/tf-az-overlays-armdeployment//modules/azure_arm_deployment/resource_group"
+  source     = "github.com/POps-Rox/terraform-az-overlays-armdeployment//modules/azure_arm_deployment/resource_group"
   count      = var.enable_sentinel && var.enable_solution_security_threat_essentials ? 1 : 0
 
   name                = "deploy_security_threat_essentials_content_solution"

--- a/modules.content.solutions.first.party.tf
+++ b/modules.content.solutions.first.party.tf
@@ -4,7 +4,7 @@
 # Enable Microsoft XDR Solution in Sentinel
 module "mod_microsoft_xdr_id" {
   depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.sentinel]
-  source     = "github.com/POps-Rox/tf-az-overlays-armdeployment//modules/azure_arm_deployment/resource_group"
+  source     = "github.com/POps-Rox/terraform-az-overlays-armdeployment//modules/azure_arm_deployment/resource_group"
   count      = var.enable_sentinel && var.enable_solution_microsoft_xdr ? 1 : 0
 
   name                = "deploy_microsoft_xdr_content_solution"
@@ -24,7 +24,7 @@ module "mod_microsoft_xdr_id" {
 # Enable Microsoft Entra ID Solution in Sentinel
 module "mod_microsoft_entra_id" {
   depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.sentinel]
-  source     = "github.com/POps-Rox/tf-az-overlays-armdeployment//modules/azure_arm_deployment/resource_group"
+  source     = "github.com/POps-Rox/terraform-az-overlays-armdeployment//modules/azure_arm_deployment/resource_group"
   count      = var.enable_sentinel && var.enable_solution_azure_ad ? 1 : 0
 
   name                = "deploy_microsoft_entra_id_content_solution"
@@ -44,7 +44,7 @@ module "mod_microsoft_entra_id" {
 # Enable Azure Active Directory Solution in Sentinel
 module "mod_azure_activity" {
   depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.sentinel]
-  source     = "github.com/POps-Rox/tf-az-overlays-armdeployment//modules/azure_arm_deployment/resource_group"
+  source     = "github.com/POps-Rox/terraform-az-overlays-armdeployment//modules/azure_arm_deployment/resource_group"
   count      = var.enable_sentinel && var.enable_solution_azure_activity ? 1 : 0
 
   name                = "deploy_azure_activity_content_solution"
@@ -64,7 +64,7 @@ module "mod_azure_activity" {
 # Enable Microsoft 365 Solution in Sentinel
 module "mod_microsoft_365" {
   depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.sentinel]
-  source     = "github.com/POps-Rox/tf-az-overlays-armdeployment//modules/azure_arm_deployment/resource_group"
+  source     = "github.com/POps-Rox/terraform-az-overlays-armdeployment//modules/azure_arm_deployment/resource_group"
   count      = var.enable_sentinel && var.enable_solution_microsoft_365 ? 1 : 0
 
   name                = "deploy_microsoft_365_content_solution"
@@ -84,7 +84,7 @@ module "mod_microsoft_365" {
 # Enable Microsoft Teams Solution in Sentinel
 module "mod_teams" {
   depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.sentinel]
-  source     = "github.com/POps-Rox/tf-az-overlays-armdeployment//modules/azure_arm_deployment/resource_group"
+  source     = "github.com/POps-Rox/terraform-az-overlays-armdeployment//modules/azure_arm_deployment/resource_group"
   count      = var.enable_sentinel && var.enable_solution_microsoft_teams ? 1 : 0
 
   name                = "deploy_microsoft_teams_content_solution"
@@ -104,7 +104,7 @@ module "mod_teams" {
 # Enable Microsoft Defender For Cloud Solution in Sentinel
 module "mod_microsoft_defender_for_cloud" {
   depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.sentinel]
-  source     = "github.com/POps-Rox/tf-az-overlays-armdeployment//modules/azure_arm_deployment/resource_group"
+  source     = "github.com/POps-Rox/terraform-az-overlays-armdeployment//modules/azure_arm_deployment/resource_group"
   count      = var.enable_sentinel && var.enable_solution_microsoft_defender_for_cloud ? 1 : 0
 
   name                = "deploy_microsoft_defender_for_cloud_solution"
@@ -124,7 +124,7 @@ module "mod_microsoft_defender_for_cloud" {
 # Enable Microsoft Defender For Endpoint Solution in Sentinel
 module "mod_microsoft_defender_for_endpoint" {
   depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.sentinel]
-  source     = "github.com/POps-Rox/tf-az-overlays-armdeployment//modules/azure_arm_deployment/resource_group"
+  source     = "github.com/POps-Rox/terraform-az-overlays-armdeployment//modules/azure_arm_deployment/resource_group"
   count      = var.enable_sentinel && var.enable_solution_microsoft_defender_for_endpoint ? 1 : 0
 
   name                = "deploy_microsoft_defender_for_endpoint_solution"
@@ -144,7 +144,7 @@ module "mod_microsoft_defender_for_endpoint" {
 # Enable Microsoft Defender For IOT Solution in Sentinel
 module "mod_microsoft_defender_for_iot" {
   depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.sentinel]
-  source     = "github.com/POps-Rox/tf-az-overlays-armdeployment//modules/azure_arm_deployment/resource_group"
+  source     = "github.com/POps-Rox/terraform-az-overlays-armdeployment//modules/azure_arm_deployment/resource_group"
   count      = var.enable_sentinel && var.enable_solution_microsoft_defender_for_iot ? 1 : 0
 
   name                = "deploy_microsoft_defender_for_iot_solution"
@@ -164,7 +164,7 @@ module "mod_microsoft_defender_for_iot" {
 # Enable Microsoft Dynamics Solution in Sentinel
 module "mod_microsoft_dynamics_365" {
   depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.sentinel]
-  source     = "github.com/POps-Rox/tf-az-overlays-armdeployment//modules/azure_arm_deployment/resource_group"
+  source     = "github.com/POps-Rox/terraform-az-overlays-armdeployment//modules/azure_arm_deployment/resource_group"
   count      = var.enable_sentinel && var.enable_solution_microsoft_dynamics_365 ? 1 : 0
 
   name                = "deploy_microsoft_dynamics_365_solution"
@@ -184,7 +184,7 @@ module "mod_microsoft_dynamics_365" {
 # Enable Office Insider Risk Management Solution in Sentinel
 module "mod_office_insider_risk_management" {
   depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.sentinel]
-  source     = "github.com/POps-Rox/tf-az-overlays-armdeployment//modules/azure_arm_deployment/resource_group"
+  source     = "github.com/POps-Rox/terraform-az-overlays-armdeployment//modules/azure_arm_deployment/resource_group"
   count      = var.enable_sentinel && var.enable_solution_office_insider_risk_management ? 1 : 0
 
   name                = "deploy_office_insider_risk_management_solution"
@@ -204,7 +204,7 @@ module "mod_office_insider_risk_management" {
 # Enable Office 365 Project Solution in Sentinel
 module "mod_office_365_project" {
   depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.sentinel]
-  source     = "github.com/POps-Rox/tf-az-overlays-armdeployment//modules/azure_arm_deployment/resource_group"
+  source     = "github.com/POps-Rox/terraform-az-overlays-armdeployment//modules/azure_arm_deployment/resource_group"
   count      = var.enable_sentinel && var.enable_solution_office_365_project ? 1 : 0
 
   name                = "deploy_office_365_project_solution"
@@ -224,7 +224,7 @@ module "mod_office_365_project" {
 # Enable Office 365 Power BI Solution in Sentinel
 module "mod_office_365_powerbi" {
   depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.sentinel]
-  source     = "github.com/POps-Rox/tf-az-overlays-armdeployment//modules/azure_arm_deployment/resource_group"
+  source     = "github.com/POps-Rox/terraform-az-overlays-armdeployment//modules/azure_arm_deployment/resource_group"
   count      = var.enable_sentinel && var.enable_solution_office_365_powerbi ? 1 : 0
 
   name                = "deploy_office_365_powerbi_solution"
@@ -244,7 +244,7 @@ module "mod_office_365_powerbi" {
 # Enable Threat Intelligence Solution in Sentinel
 module "mod_threat_intelligence" {
   depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.sentinel]
-  source     = "github.com/POps-Rox/tf-az-overlays-armdeployment//modules/azure_arm_deployment/resource_group"
+  source     = "github.com/POps-Rox/terraform-az-overlays-armdeployment//modules/azure_arm_deployment/resource_group"
   count      = var.enable_sentinel && var.enable_solution_threat_intelligence ? 1 : 0
 
   name                = "deploy_threat_intelligence_solution"
@@ -264,7 +264,7 @@ module "mod_threat_intelligence" {
 # Enable SOC Handbook Solution in Sentinel
 module "mod_soc_handbook" {
   depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.sentinel]
-  source     = "github.com/POps-Rox/tf-az-overlays-armdeployment//modules/azure_arm_deployment/resource_group"
+  source     = "github.com/POps-Rox/terraform-az-overlays-armdeployment//modules/azure_arm_deployment/resource_group"
   count      = var.enable_sentinel && var.enable_solution_soc_handbook ? 1 : 0
 
   name                = "deploy_soc_handbook_solution"
@@ -284,7 +284,7 @@ module "mod_soc_handbook" {
 # Enable SOC Handbook Solution in Sentinel
 module "mod_soc_process_fx" {
   depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.sentinel]
-  source     = "github.com/POps-Rox/tf-az-overlays-armdeployment//modules/azure_arm_deployment/resource_group"
+  source     = "github.com/POps-Rox/terraform-az-overlays-armdeployment//modules/azure_arm_deployment/resource_group"
   count      = var.enable_sentinel && var.enable_solution_soc_process_fx ? 1 : 0
 
   name                = "deploy_soc_process_fx_solution"

--- a/modules.content.solutions.training.tf
+++ b/modules.content.solutions.training.tf
@@ -5,7 +5,7 @@
 # Enable Sentinel KQL Training Solution
 module "mod_kql_training" {
   depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.sentinel]
-  source     = "github.com/POps-Rox/tf-az-overlays-armdeployment//modules/azure_arm_deployment/resource_group"
+  source     = "github.com/POps-Rox/terraform-az-overlays-armdeployment//modules/azure_arm_deployment/resource_group"
   count      = var.enable_sentinel && var.enable_solution_kql_training ? 1 : 0
 
   name                = "deploy_kql_training_content_solution"
@@ -25,7 +25,7 @@ module "mod_kql_training" {
 # Enable Sentinel Training Lab Solution
 module "mod_training_lab" {
   depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.sentinel]
-  source     = "github.com/POps-Rox/tf-az-overlays-armdeployment//modules/azure_arm_deployment/resource_group"
+  source     = "github.com/POps-Rox/terraform-az-overlays-armdeployment//modules/azure_arm_deployment/resource_group"
   count      = var.enable_sentinel && var.enable_solution_training_lab ? 1 : 0
 
   name                = "deploy_training_lab_content_solution"


### PR DESCRIPTION
## Summary
GitHub renamed these repos from `tf-az-overlays-*` to `terraform-az-overlays-*` in a prior cleanup, but module `source =` references in `.tf` files and `catalog-info.yaml` annotations still use the old slug. Terraform module downloads currently succeed only via GitHub's 301 redirect — fragile and prone to break.

## Changes
- All `.tf` files: `POps-Rox/tf-az-overlays-*` → `POps-Rox/terraform-az-overlays-*`
- All `.tf` files: `POps-Rox/tf-az-entra-overlays-*` → `POps-Rox/terraform-az-entra-overlays-*`
- `catalog-info.yaml`: `metadata.name` and `github.com/project-slug` annotation updated to match actual repo name

## Validation
```bash
grep -rln 'POps-Rox/tf-az-overlays\|pops-rox/tf-az-overlays' --include='*.tf' .
grep -l 'tf-az-overlays\|tf-az-entra-overlays' catalog-info.yaml
```
Both return no output after this PR.

Part of the POps-Rox Go-To-Market initiative.