### PR TITLE
fix: resolve 4.x validation/CI failures

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,6 +1,11 @@
 
 locals {
-  workspace_id                  = var.enable_sentinel_onboarding ? azurerm_sentinel_log_analytics_workspace_onboarding.sentinel[0].workspace_id : var.log_analytics_workspace_id
-  workspace_name                = var.enable_sentinel_onboarding ? azurerm_sentinel_log_analytics_workspace_onboarding.sentinel[0].workspace_name : var.log_analytics_workspace_name
-  workspace_resource_group_name = var.enable_sentinel_onboarding ? azurerm_sentinel_log_analytics_workspace_onboarding.sentinel[0].resource_group_name : var.log_analytics_workspace_resource_group_name
+  workspace_id = var.enable_sentinel_onboarding ? azurerm_sentinel_log_analytics_workspace_onboarding.sentinel[0].workspace_id : var.log_analytics_workspace_id
+  # azurerm 4.x removed `workspace_name` and `resource_group_name` from
+  # `azurerm_sentinel_log_analytics_workspace_onboarding`; derive them by
+  # parsing the ARM resource ID:
+  #   /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.OperationalInsights/workspaces/{name}
+  _workspace_id_parts           = split("/", local.workspace_id)
+  workspace_name                = var.enable_sentinel_onboarding ? local._workspace_id_parts[8] : var.log_analytics_workspace_name
+  workspace_resource_group_name = var.enable_sentinel_onboarding ? local._workspace_id_parts[4] : var.log_analytics_workspace_resource_group_name
 }

--- a/resources.sentinel.scheduled.alert.rule.tf
+++ b/resources.sentinel.scheduled.alert.rule.tf
@@ -64,21 +64,21 @@ resource "azurerm_sentinel_alert_rule_scheduled" "rule" {
     }
   }
 
-  dynamic "incident_configuration" {
+  dynamic "incident" {
     for_each = try(lookup(each.value.incident_configuration, "incident_configuration"), [])
     content {
-      create_incident = try(incident_configuration.value["create_incident"])
+      create_incident_enabled = try(incident.value["create_incident"])
 
       dynamic "grouping" {
-        for_each = try(incident_configuration.value["grouping"])
+        for_each = try(incident.value["grouping"])
         content {
           enabled                 = grouping.value["enabled"]
           lookback_duration       = grouping.value["lookback_duration"]
           reopen_closed_incidents = grouping.value["reopen_closed_incidents"]
           entity_matching_method  = grouping.value["entity_matching_method"]
-          group_by_entities       = grouping.value["group_by_entities"]
-          group_by_alert_details  = grouping.value["group_by_alert_details"]
-          group_by_custom_details = grouping.value["group_by_custom_details"]
+          by_entities             = grouping.value["group_by_entities"]
+          by_alert_details        = grouping.value["group_by_alert_details"]
+          by_custom_details       = grouping.value["group_by_custom_details"]
         }
       }
     }


### PR DESCRIPTION
Post-merge fix for CI failures introduced by Phase 1 4.x migration.

**Failing job:** Terraform Validate (root module)
**Root causes (azurerm 4.x breaking changes):**
1. `azurerm_sentinel_log_analytics_workspace_onboarding` lost `workspace_name` / `resource_group_name` exports → derived from workspace ARM ID
2. `azurerm_sentinel_alert_rule_scheduled.incident_configuration` renamed to `incident`
3. `incident.grouping` attributes renamed: `create_incident` → `create_incident_enabled`, `group_by_*` → `by_*`

Public module input shape (`incident_configuration` keys in `var.scheduled_alert_rules`) is preserved.

Validated locally:
- `terraform fmt -recursive -check` ✅
- `terraform validate` ✅